### PR TITLE
Use semver compliant version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DualVNH5019MotorShieldMod3
-version=2.0.0.dualshilds
+version=2.0.0-dualshilds
 author=Pololu/photodude
 maintainer=Photodude <info@waltsorensen.com>
 sentence=Arduino library for the running two Pololu Dual VNH5019 Motor Driver Shields on an Arduino Mega

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DualVNH5019MotorShieldMod3
-version=2.0.0-dualshilds
+version=3.0.0-dualshilds
 author=Pololu/photodude
 maintainer=Photodude <info@waltsorensen.com>
 sentence=Arduino library for the running two Pololu Dual VNH5019 Motor Driver Shields on an Arduino Mega


### PR DESCRIPTION
Non-semver compliant `version` value causes the Arduino IDE to display warnings:
`
Invalid version found: 2.0.0.dualshilds
`
This can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Note also that you forgot to update the version before the last release of the library.

References:
- https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format
- https://semver.org/